### PR TITLE
Solve possible UnboundLocalError.

### DIFF
--- a/psshlib/askpass_server.py
+++ b/psshlib/askpass_server.py
@@ -68,6 +68,7 @@ class PasswordServer(object):
     def handle_write(self, fd, iomap):
         buffer = self.buffermap[fd]
         conn = self.socketmap[fd]
+        bytes_written = 0
         try:
             bytes_written = conn.send(buffer)
         except socket.error:


### PR DESCRIPTION
Happened to me (see below). I know handling this case could be done different (stop/return after closing the socket probably), but my insight to the possible consequences is limited so i opted for the obvious solution to declare "bytes_written" ...

Traceback (most recent call last):
  File "/usr/bin/parallel-ssh", line 119, in <module>
    do_pssh(hosts, cmdline, opts)
  File "/usr/bin/parallel-ssh", line 110, in do_pssh
    manager.run()
  File "/usr/lib/pymodules/python2.6/psshlib/manager.py", line 67, in run
    self.iomap.poll(wait)
  File "/usr/lib/pymodules/python2.6/psshlib/manager.py", line 242, in poll
    handler(fd, self)
  File "/usr/lib/pymodules/python2.6/psshlib/askpass_server.py", line 77, in handle_write
    buffer = buffer[bytes_written:]
UnboundLocalError: local variable 'bytes_written' referenced before assignment
